### PR TITLE
fix: include wit files with package

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "files": [
     "lib",
     "types",
-    "plugin"
+    "plugin",
+    "wit"
   ]
 }


### PR DESCRIPTION
wit files are not included with the package on `npm`. This leads to 
```
[webpack-cli] ComponentError: failed to read path for WIT [.../node_modules/@spinframework/wasi-ext/wit]
```
This PR modifies `package.json` to include the `wit` folder in the package